### PR TITLE
iOS and deprecation fixes

### DIFF
--- a/__tests__/modules/to-dos.spec.js
+++ b/__tests__/modules/to-dos.spec.js
@@ -18,7 +18,7 @@ describe('ToDosReducer', () => {
         const expectedState = [undoneToDo];
         expect(ToDosReducer(initialState, action)).toEqual(expectedState);
     });
-    it('toggles correctly a undone ToDo', () => {
+    it('toggles correctly an undone ToDo', () => {
         const initialState = [undoneToDo];
         const action = toggleTodo(2);
         const expectedState = [doneToDo];

--- a/app/app.js
+++ b/app/app.js
@@ -42,7 +42,7 @@ const styles = StyleSheet.create({
 
     headertext: {
         fontSize: 32,
-        fontFamily: 'bold',
+        fontWeight: 'bold',
         textAlign: 'center',
         margin: 10,
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"jest": "19.0.2",
 		"react-addons-test-utils": "^15.5.1",
 		"react-dom": "^15.5.4",
-		"react-test-renderer": "15.4.2"
+		"react-test-renderer": "^15.5.4"
 	},
 	"jest": {
 		"preset": "react-native"

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,11 +810,7 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.21.0, babel-types@^6.22
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.14.1, babylon@^6.15.0:
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
-
-babylon@^6.17.0:
+babylon@^6.11.0, babylon@^6.13.0, babylon@^6.14.1, babylon@^6.15.0, babylon@^6.17.0:
   version "6.17.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
 
@@ -3702,11 +3698,11 @@ react-redux@^5.0.3:
     lodash-es "^4.2.0"
     loose-envify "^1.1.0"
 
-react-test-renderer@15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.4.2.tgz#27e1dff5d26d0e830f99614c487622bc831416f3"
+react-test-renderer@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     object-assign "^4.1.0"
 
 react-timer-mixin@^0.13.2:


### PR DESCRIPTION
* The incorrect styling was not accepted by iOS (red screen).
* Minor typo.
* The deprecation warning can be fixed by adding react-rest-renderer.